### PR TITLE
Add option to not specify MAC address for tap dev.

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -23,7 +23,8 @@ type deviceWithLatency struct {
 // Basically initializes latency and then delegates to the tapDevice version of
 // NewTapDevice. For bandwidth parameters, 0 means no limitation.
 // Args:
-//	mac: MAC address of the device.
+//	mac: MAC address of the device. If it is an empty string, no specific
+//	address will be set.
 //  dev: A name for the device.
 //	send_bandwidth: Maximum number of outgoing bytes per second.
 //  receive_bandwidth: Maximum number of incoming bytes per second.

--- a/tap_device.go
+++ b/tap_device.go
@@ -25,15 +25,17 @@ func NewTapDevice(mac, dev string) (FrameReadWriteCloser, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command(ip_path, "link", "set", "dev", dev, "address", mac)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Print("Command output:", string(output))
-		return nil, err
+	if mac != "" {
+		cmd := exec.Command(ip_path, "link", "set", "dev", dev, "address", mac)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Print("Command output:", string(output))
+			return nil, err
+		}
 	}
 
-	cmd = exec.Command(ip_path, "link", "set", "dev", dev, "up")
-	output, err = cmd.CombinedOutput()
+	cmd := exec.Command(ip_path, "link", "set", "dev", dev, "up")
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Print("Command output:", string(output))
 		return nil, err


### PR DESCRIPTION
Specifying a MAC address causes some of the integration tests
that rely on loopback2 to freak out for some reason.